### PR TITLE
Refactor: Improve Config type safety and consistency

### DIFF
--- a/src/Managers/Cache/IdempotencyCacheManager.php
+++ b/src/Managers/Cache/IdempotencyCacheManager.php
@@ -12,11 +12,11 @@ class IdempotencyCacheManager
 {
     private const CACHE_KEY = 'idempotences:%s:users:%s:data';
     private const CACHE_TTL = 86400; // 24 hours
-    private const DEFAULT_MAX_LOCK_WAIT_TIME = 10; // 10 seconds
 
     public function __construct(
         private readonly CacheRepository $cacheRepository,
-        private readonly LockProvider $lockProvider
+        private readonly LockProvider $lockProvider,
+        private readonly IdempotencyConfig $config
     ) {
     }
 
@@ -27,7 +27,7 @@ class IdempotencyCacheManager
 
     private function getMaxLockWaitTime(): int
     {
-        return (int) IdempotencyConfig::get(IdempotencyConfig::MAX_LOCK_WAIT_TIME_KEY, self::DEFAULT_MAX_LOCK_WAIT_TIME);
+        return $this->config->getMaxLockWaitTime();
     }
 
     public function hasIdempotency(string $idempotencyKey, string $userId): bool
@@ -50,7 +50,7 @@ class IdempotencyCacheManager
         return $this->cacheRepository->put(
             $this->getCacheKey($userId, $idempotency->getIdempotencyKey()),
             $idempotency,
-            (int) IdempotencyConfig::get(IdempotencyConfig::CACHE_TTL_KEY, self::CACHE_TTL)
+            $this->config->getCacheTtl(self::CACHE_TTL)
         );
     }
 

--- a/src/Providers/IdempotencyServiceProvider.php
+++ b/src/Providers/IdempotencyServiceProvider.php
@@ -4,12 +4,18 @@ namespace AlgoYounes\Idempotency\Providers;
 
 use AlgoYounes\Idempotency\Config\IdempotencyConfig;
 use AlgoYounes\Idempotency\Managers\Cache\IdempotencyCacheManager;
+use AlgoYounes\Idempotency\Resolvers\NullUserIdResolver;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
 class IdempotencyServiceProvider extends ServiceProvider
 {
+    private ?IdempotencyConfig $config = null;
+
     public function boot(): void
     {
         $this->publishes([
@@ -22,28 +28,58 @@ class IdempotencyServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/config/idempotency.php', 'idempotency');
 
         $this->app->singleton(
-            IdempotencyCacheManager::class,
-            function (array $app): IdempotencyCacheManager {
-                $cacheRepository = $app['cache']->store($this->getCacheStoreName());
-                $lockProvider = $app[LockProvider::class];
+            IdempotencyConfig::class,
+            function (Application $app): IdempotencyConfig {
+                /** @var ConfigRepository $configRepository */
+                $configRepository = $app->make(ConfigRepository::class);
+                $config = (array) $configRepository->get('idempotency', []);
 
-                return new IdempotencyCacheManager($cacheRepository, $lockProvider);
+                return IdempotencyConfig::createFromArray($config);
             }
         );
 
-        $this->app->bind(CacheRepository::class, fn (array $app) => $app['cache']->store($this->getCacheStoreName()));
+        $this->app->singleton(
+            IdempotencyCacheManager::class,
+            function (Application $app): IdempotencyCacheManager {
+                /** @var LockProvider $lockProvider */
+                $lockProvider = $app->make(LockProvider::class);
 
-        $this->app->bind(CacheRepository::class, fn (array $app) => $app['cache']->store($this->getCacheStoreName()));
+                return new IdempotencyCacheManager($this->getCacheRepository($app), $lockProvider, $this->getConfig($app));
+            }
+        );
+
+        $this->app->bind(CacheRepository::class, fn (Application $app): CacheRepository => $this->getCacheRepository($app));
+
+        NullUserIdResolver::setConfig($this->getConfig());
+    }
+    private function getCacheRepository(Application $app): CacheRepository
+    {
+        /** @var CacheFactory $cacheFactory */
+        $cacheFactory = $app->make(CacheFactory::class);
+
+        return $cacheFactory->store($this->getCacheStoreName());
     }
 
     private function getCacheStoreName(): string
     {
-        $cacheStore = IdempotencyConfig::get(IdempotencyConfig::CACHE_STORE_KEY, 'default');
+        $cacheStore = $this->getConfig()->getCacheStore();
         if ($cacheStore === 'default') {
             // @phpstan-ignore-next-line
             return config('cache.default');
         }
 
         return $cacheStore;
+    }
+
+    private function getConfig(?Application $app = null): IdempotencyConfig
+    {
+        if ($this->config instanceof IdempotencyConfig) {
+            return $this->config;
+        }
+
+        /** @var IdempotencyConfig $config */
+        $config = ($app ?? $this->app)->make(IdempotencyConfig::class);
+
+        return $this->config = $config;
     }
 }

--- a/src/Resolvers/NullUserIdResolver.php
+++ b/src/Resolvers/NullUserIdResolver.php
@@ -6,9 +6,16 @@ use AlgoYounes\Idempotency\Config\IdempotencyConfig;
 
 class NullUserIdResolver
 {
+    private static IdempotencyConfig $config;
+
+    public static function setConfig(IdempotencyConfig $config): void
+    {
+        self::$config = $config;
+    }
+
     public static function resolve(): string
     {
-        $value = IdempotencyConfig::get(IdempotencyConfig::UNAUTHENTICATED_USER_ID_KEY, 'guest');
+        $value = self::$config->getUnauthenticatedUserId();
         if (! is_string($value)) {
             return 'guest';
         }

--- a/src/Resolvers/UserIdResolver.php
+++ b/src/Resolvers/UserIdResolver.php
@@ -8,10 +8,12 @@ use Illuminate\Contracts\Auth\Guard;
 readonly class UserIdResolver
 {
     private Guard $auth;
+    private IdempotencyConfig $config;
 
     public function __construct()
     {
         $this->auth = make(Guard::class);
+        $this->config = make(IdempotencyConfig::class);
     }
 
     public static function resolve(): string
@@ -21,8 +23,8 @@ readonly class UserIdResolver
 
     private function getUserId(): string
     {
-        $customResolver = IdempotencyConfig::get(IdempotencyConfig::USER_ID_RESOLVER_KEY);
-        if (is_array($customResolver) && count($customResolver) === 2) {
+        $customResolver = $this->config->getUserIdResolver();
+        if (count($customResolver) === 2) {
             return $this->getCustomUserId($customResolver);
         }
 


### PR DESCRIPTION
Key Changes :
- Updated IdempotencyServiceProvider to ensure proper type handling
- Ensured `$config` property is properly typed as IdempotencyConfig
- Used the make method consistently to retrieve configuration instances
- Added phpdoc annotations to enforce correct types
- Improved type safety for cache repository and lock provider resolution
- Removed mixed type issues to satisfy PHPStan checks